### PR TITLE
Update README: preload was moved

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ python manage.py createsuperuser
 ##### 6. Preload the static database data
 
 ```
-python manage.py loaddata ./script/preload/*
+python manage.py loaddata ./preload/*
 ```
     
 ##### 7. Start the message broker, celery worker, and website server


### PR DESCRIPTION
Minor edit to the README to reflect that loaddata scripts are now in ./preload instead of ./script/preload.