### PR TITLE
Disable logging of _sample and _raw data

### DIFF
--- a/website/settings.py-SAMPLE
+++ b/website/settings.py-SAMPLE
@@ -112,13 +112,6 @@ USE_L10N = True
 USE_TZ = True
 
 
-FILE_UPLOAD_DIRECTORY_PERMISSIONS = 0o644
-FILE_UPLOAD_PERMISSIONS = 0o644
-
-#UPLOAD_DIR = '/var/www/oltpbench/media'
-UPLOAD_DIR = '/Users/zhangbohan/.git/website/data/media'
-
-
 # Static files (CSS, JavaScript, Images)
 STATICFILES_DIRS = (
    os.path.join(PROJECT_ROOT, "static"),

--- a/website/urls.py
+++ b/website/urls.py
@@ -21,7 +21,6 @@ urlpatterns = [
 
     url(r'^new_result/', website_views.new_result),
     url(r'^result/', website_views.result),
-    url(r'^get_result_data_file/', website_views.get_result_data_file),
     url(r'^update_similar/', website_views.update_similar),
 
     url(r'^edit_project/', website_views.edit_project),


### PR DESCRIPTION
Previously we were storing _sample data (~2KB) and _raw data (~2MB) per upload.

This data wasn't actually being used anywhere, apart from letting people download it, so we removed it.